### PR TITLE
 Add defaultMimeType

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var prop = require('mincer/lib/mincer/common').prop;
+
 // stdlib
 var path = require('path');
 
@@ -47,5 +49,6 @@ module.exports = function addBabelEngine(Mincer, babel) {
 	};
 
 	Mincer.registerEngine('.es6', Mincer.BabelEngine);
-
+	
+	prop(Mincer.BabelEngine, 'defaultMimeType', 'application/javascript');
 };


### PR DESCRIPTION
Defining the defaultMimeType allows you to have `.es6` files instead of `.js.es6`.
And of course your `.js.es6` files still works.
