### PR TITLE
Update dependencies to be compatible with Mincer 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mincer": "^1.2.4"
   },
   "peerDependencies": {
-    "mincer": "~1.2 || ~1.3"
+    "mincer": "~1.2 || ~1.3 || ~1.4"
   },
   "dependencies": {
     "babel-core": "^5.2.17"


### PR DESCRIPTION
Otherwise NPM show this warning message:
`WARN EPEERINVALID mincer-babel@0.0.4 requires a peer of mincer@~1.2 || ~1.3 but none was installed.`
