### PR TITLE
Allow babel options to be passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 // Second param is not mandatory, used only to force specific
 // module version when nested dependencies cause conflict.
-module.exports = function addBabelEngine(Mincer, babel) {
+module.exports = function addBabelEngine(Mincer, babel, babelOptions) {
 
 	var BabelEngine = Mincer.BabelEngine = function BabelEngine() {
 		Mincer.Template.apply(this, arguments);
@@ -21,11 +21,13 @@ module.exports = function addBabelEngine(Mincer, babel) {
 		var source = this.data;
 		var dir = path.dirname(context.pathname);
 
-		var transformed = babel.transform(source, {
-			sourceMaps: withSourcemap,
-			inputSourceMap: this.map,
-			sourceRoot: path.dirname(context.pathname)
-		});
+		babelOptions = Object.assign({
+					sourceMaps: withSourcemap,
+					inputSourceMap: this.map,
+					sourceRoot: path.dirname(context.pathname)
+				}, babelOptions);
+				
+		var transformed = babel.transform(source, babelOptions);
 
 		this.data = transformed.code;
 


### PR DESCRIPTION
Currently, `mincer-babel` hard codes the options to be sent to babel. This PR allows additional `babel` options to be passed in. This is very helpful, especially for `babel 6` where you need to set some presets. This enables code like this:

```
var assets = require('connect-assets');
require('mincer-babel')(assets.Mincer, require('babel-core'), {
  presets: ['es2015', 'stage-0']
});
app.use(assets({}));
```

(note, the second parameter there where I'm passing in `require('babel-core')` is me requiring my local (later) version of babel which is great that `babel-mincer` currently supports)

Thanks!
