### PR TITLE
Remove the need to 'require('mincer')'

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,5 +50,5 @@ module.exports = function addBabelEngine(Mincer, babel) {
 
 	Mincer.registerEngine('.es6', Mincer.BabelEngine);
 
-	prop(Mincer.BabelEngine, 'defaultMimeType', 'application/javascript');
+	Object.defineProperty(Mincer.BabelEngine, 'defaultMimeType', {value: 'application/javascript'});
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var prop = require('mincer/lib/mincer/common').prop;
-
 // stdlib
 var path = require('path');
 


### PR DESCRIPTION
I got the following error:

```
web_1      |     Error: Cannot find module 'mincer/lib/mincer/common'
web_1      |     at Function.Module._resolveFilename (module.js:325:15)
web_1      |     at Function.Module._load (module.js:276:25)
web_1      |     at Module.require (module.js:353:17)
web_1      |     at require (internal/module.js:12:17)
web_1      |     at Object.<anonymous> (/novatube/node_modules/mincer-babel/index.js:3:12)
web_1      |     at Module._compile (module.js:409:26)
web_1      |     at Object.Module._extensions..js (module.js:416:10)
web_1      |     at Module.load (module.js:343:32)
web_1      |     at Function.Module._load (module.js:300:12)
web_1      |     at Module.require (module.js:353:17)
web_1      |     at require (internal/module.js:12:17)
web_1      |     at Object.<anonymous> (/novatube/app.js:23:1)
web_1      |     at Module._compile (module.js:409:26)
web_1      |     at Object.Module._extensions..js (module.js:416:10)
web_1      |     at Module.load (module.js:343:32)
web_1      |     at Function.Module._load (module.js:300:12)
web_1      |     at Function.Module.runMain (module.js:441:10)
web_1      |     at startup (node.js:139:18)
web_1      |     at node.js:968:3
```

which I fixed [in this repo](https://github.com/aug-riedinger/mincer-jsx/blob/master/index.js) by using straight `Object.defineProperty`;

There might be a better solution (like accessing the `prop` method within the `Mincer` object) but for now it does the job.
